### PR TITLE
Fixing initialization kwargs.

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -260,7 +260,8 @@ def _get_serializer(app, name):
 
 def _get_state(app, datastore, anonymous_user=None, **kwargs):
     for key, value in get_config(app).items():
-        kwargs[key.lower()] = value
+        if kwargs.get(key.lower()) is None:
+            kwargs[key.lower()] = value
 
     kwargs.update(dict(
         app=app,


### PR DESCRIPTION
Currently, the args passed to `init_app` & `_get_state` are overwritten by the app / default config values. The `kwargs` should take a higher precedence.
